### PR TITLE
fix: charmap error when using logInTextFile on pc

### DIFF
--- a/uwu.py
+++ b/uwu.py
@@ -1002,7 +1002,7 @@ class MyClient(commands.Bot):
             )
             with lock:
                 if self.misc["debug"]["logInTextFile"]:
-                    with open("logs.txt", "a") as log:
+                    with open("logs.txt", "a", encoding="utf-8") as log:
                         log.write(f"{content_to_print}\n")
         else:
             console.print(f"{self.username}| {text}".center(console_width - 2), style=color)


### PR DESCRIPTION
I got this solution from [stackoverflow](https://stackoverflow.com/a/42495690)
and idk how this will behave on termux because it worked there but ig it shouldnt mess anything up


btw what is [#676585]?

on Windows 11 python 3.13  (idk if its just me) when misc.json --> logInTextFile = true this happens
<img width="1447" height="837" alt="image" src="https://github.com/user-attachments/assets/b12cfb9e-868a-4b3e-b4e9-f69cd6258d3e" />
After:
<img width="1356" height="626" alt="image" src="https://github.com/user-attachments/assets/275a365e-7c02-4835-b354-fe25ec5e42d4" />
