### PR TITLE
fix: notifyStreakLoss

### DIFF
--- a/cogs/battle.py
+++ b/cogs/battle.py
@@ -71,7 +71,7 @@ class Battle(commands.Cog):
                                     await self.bot.log(
                                         f"{embed.footer.text}", "#292252"
                                     )
-                                if "You lost your streak of" in embed.footer.text:
+                                if "You lost in " in embed.footer.text:
                                     if self.bot.settings_dict["commands"]["battle"][
                                         "notifyStreakLoss"
                                     ]:


### PR DESCRIPTION
why you undo my commit 😔

so, basically the new message is 
example: `You lost in 21 turns! | +69 xp  |  Streak ended at 67`
there is no `... your streak of ...`
so the streak loss would never be detected