### PR TITLE
Add daily run command and fix daily command scheduling

### DIFF
--- a/cogs/pupiku.py
+++ b/cogs/pupiku.py
@@ -41,6 +41,8 @@ class Pupiku(BaseCog):
             "pup": {"command_send_time": 0, "command_resp_time": 0},
             "piku": {"command_send_time": 0, "command_resp_time": 0},
         }
+        self.completed_today = set()
+        self.tomorrow_tasks = {}
 
     @property
     def pup_settings(self):
@@ -49,6 +51,14 @@ class Pupiku(BaseCog):
     @property
     def piku_settings(self):
         return self.bot.settings_dict_temp.commands.piku
+
+    def enabled_commands(self):
+        cmds = []
+        if self.pup_settings.enabled:
+            cmds.append("pup")
+        if self.piku_settings.enabled:
+            cmds.append("piku")
+        return cmds
 
     def set_and_validate_resp_time(self, cmd_name: str):
         # 1. set resp time
@@ -78,6 +88,34 @@ class Pupiku(BaseCog):
     def set_send_time(self, cmd_name: str):
         self.command_status[cmd_name]["command_send_time"] = time.monotonic()
 
+    async def mark_complete_today(self, cmd_name: str):
+        self.completed_today.add(cmd_name)
+        self.bot.db.update_cmd_lastran_time(cmd_name)
+        await self.bot.remove_queue(id=cmd_name)
+
+        task = self.tomorrow_tasks.pop(cmd_name, None)
+        if task and not task.done():
+            task.cancel()
+        self.tomorrow_tasks[cmd_name] = asyncio.create_task(
+            self.resume_tomorrow(cmd_name)
+        )
+
+    async def resume_tomorrow(self, cmd_name: str):
+        await asyncio.sleep(self.bot.calc_time())
+        self.completed_today.discard(cmd_name)
+        await self.send_pupiku(cmd=cmd_name, initial=True)
+
+    def detect_command_result(self, content: str):
+        if "Your garden is out of carrots!" in content:
+            return "piku", True
+        if "There are no puppies to adopt!" in content:
+            return "pup", True
+        if "You picked one PikPik carrot" in content:
+            return "piku", "today!" in content
+        if "You picked up one puppy" in content:
+            return "pup", "today!" in content
+        return "", False
+
     async def cog_load(self):
         if not (self.pup_settings.enabled or self.piku_settings.enabled):
             try:
@@ -85,30 +123,63 @@ class Pupiku(BaseCog):
             except ExtensionNotLoaded:
                 pass
         else:
-            asyncio.create_task(self.send_buy(send_pupiku=True))
+            asyncio.create_task(self.send_pupiku(startup=True))
 
     async def cog_unload(self):
         await self.bot.remove_queue(id="pup")
         await self.bot.remove_queue(id="piku")
+        for task in self.tomorrow_tasks.values():
+            if not task.done():
+                task.cancel()
 
-    async def send_pupiku(self, startup=False, cmd=None, final=False):
+    async def send_pupiku(
+        self, startup=False, cmd=None, final=False, initial=False, initial_delay=0
+    ):
         if startup:
             await self.bot.sleep_till(
                 self.bot.settings_dict_temp.cooldowns.shortCooldown
             )
-            cmds = ["pup", "piku"]
-            choice = self.bot.random.choice(cmds)
-            cmds.remove(choice)
+            cmds = self.enabled_commands()
+            self.bot.random.shuffle(cmds)
 
-            await self.bot.put_queue(self.__dict__[f"{choice}_cmd"])
-            await self.bot.sleep_till([1,3])
-            await self.bot.put_queue(self.__dict__[f"{cmds[0]}_cmd"])
+            delay = 0
+            for index, cmd_name in enumerate(cmds):
+                if index:
+                    delay += self.bot.random.uniform(1, 3)
+                asyncio.create_task(
+                    self.send_pupiku(
+                        cmd=cmd_name, initial=True, initial_delay=delay
+                    )
+                )
         else:
-            await self.bot.remove_queue(id=cmd)
-            cd = self.__dict__[f"{cmd}_settings"].get_cd()
-            if final:
-                cd+=self.bot.calc_time()
-            await self.bot.sleep(cd)
+            if cmd not in self.enabled_commands():
+                return
+            if cmd in self.completed_today:
+                return
+
+            if initial_delay:
+                await asyncio.sleep(initial_delay)
+            if cmd in self.completed_today:
+                return
+
+            if initial:
+                last_ran = await self.bot.db.fetch_cmd_lastran_time(cmd)
+                if not self.bot.should_run(last_ran):
+                    self.completed_today.add(cmd)
+                    self.tomorrow_tasks[cmd] = asyncio.create_task(
+                        self.resume_tomorrow(cmd)
+                    )
+                    return
+            else:
+                await self.bot.remove_queue(id=cmd)
+                if final:
+                    await self.mark_complete_today(cmd)
+                    return
+                else:
+                    await self.bot.sleep(getattr(self, f"{cmd}_settings").get_cd())
+                    if cmd in self.completed_today:
+                        return
+
             self.set_send_time(cmd)
             await self.bot.put_queue(self.__dict__[f"{cmd}_cmd"])
 
@@ -121,30 +192,17 @@ class Pupiku(BaseCog):
         if message.author.id != self.bot.owo_bot_id:
             return
 
-        final = False
-        cmd = ""
-        if "You picked one PikPik carrot" in message.content:
-            cmd = "piku"
-        elif "You picked up one puppy" in message.content:
-            cmd = "pup"
-        if "today!" in message.content:
-            # its a weird method, but the `!` at the end always exists
-            # when the day's total pup/piku is ran. A solid way to detect finish!
-            final = True
-
-        if cmd and self.set_and_validate_resp_time(cmd):
-            await self.send_pupiku(cmd=cmd, final=final)
+        detected_cmd, detected_final = self.detect_command_result(message.content)
+        if detected_cmd:
+            if detected_cmd not in self.enabled_commands():
+                return
+            if detected_final:
+                await self.mark_complete_today(detected_cmd)
+                return
+            if self.set_and_validate_resp_time(detected_cmd):
+                await self.send_pupiku(cmd=detected_cmd, final=detected_final)
             return
 
-        cmd = ""
-        if "🚫 **|** Your garden is out of carrots!" in message.content:
-            cmd = "piku"
-        elif "🚫 **|** There are no puppies to adopt!" in message.content:
-            cmd = "pup"
-
-        if cmd and self.set_and_validate_resp_time(cmd):
-            # command may have been ran and done in previous session
-            await self.send_pupiku(cmd=cmd, final=final)
 
 
         

--- a/cogs/run.py
+++ b/cogs/run.py
@@ -1,0 +1,98 @@
+# This file is part of owo-dusk.
+#
+# Copyright (c) 2024-present EchoQuill
+
+import asyncio
+
+from discord.ext import commands
+from discord.ext.commands import ExtensionNotLoaded
+from cogs._BASE import BaseCog
+
+
+class Run(BaseCog):
+    def __init__(self, bot):
+        super().__init__(bot)
+        self.cmd = {
+            "cmd_name": self.bot.alias["run"]["normal"],
+            "prefix": True,
+            "checks": True,
+            "id": "run",
+        }
+        self.completed_today = False
+        self.tomorrow_task = None
+
+    @property
+    def settings(self):
+        return self.bot.settings_dict_temp.commands.run
+
+    async def cog_load(self):
+        if not self.settings.enabled:
+            try:
+                asyncio.create_task(self.bot.unload_cog("cogs.run"))
+            except ExtensionNotLoaded:
+                pass
+        else:
+            asyncio.create_task(self.send_run(startup=True))
+
+    async def cog_unload(self):
+        await self.bot.remove_queue(id="run")
+        if self.tomorrow_task and not self.tomorrow_task.done():
+            self.tomorrow_task.cancel()
+
+    def is_final_message(self, content: str):
+        return "You are too tired to run!" in content
+
+    def is_run_response(self, content: str):
+        return self.is_final_message(content) or "You ran " in content
+
+    async def mark_complete_today(self):
+        self.completed_today = True
+        self.bot.db.update_cmd_lastran_time("run")
+        await self.bot.remove_queue(id="run")
+
+        if self.tomorrow_task and not self.tomorrow_task.done():
+            self.tomorrow_task.cancel()
+        self.tomorrow_task = asyncio.create_task(self.resume_tomorrow())
+
+    async def resume_tomorrow(self):
+        await asyncio.sleep(self.bot.calc_time())
+        self.completed_today = False
+        await self.send_run(startup=True)
+
+    async def send_run(self, startup=False):
+        if self.completed_today:
+            return
+
+        if startup:
+            last_ran = await self.bot.db.fetch_cmd_lastran_time("run")
+            if not self.bot.should_run(last_ran):
+                self.completed_today = True
+                self.tomorrow_task = asyncio.create_task(self.resume_tomorrow())
+                return
+            await self.bot.sleep_till(self.bot.settings_dict_temp.cooldowns.shortCooldown)
+        else:
+            await self.bot.remove_queue(id="run")
+            await self.bot.sleep(self.settings.get_cd())
+            if self.completed_today:
+                return
+
+        await self.bot.put_queue(self.cmd)
+
+    @commands.Cog.listener()
+    async def on_message(self, message):
+        if not message.channel.id == self.bot.cm.id:
+            return
+
+        if message.author.id != self.bot.owo_bot_id:
+            return
+
+        if self.is_final_message(message.content):
+            await self.mark_complete_today()
+            return
+
+        if self.is_run_response(message.content):
+            await self.send_run()
+
+
+async def setup(bot):
+    await bot.add_cog(Run(bot))

--- a/cogs/sell.py
+++ b/cogs/sell.py
@@ -65,11 +65,11 @@ class Sell(BaseCog):
 
     @property
     def sell_settings(self):
-        self.bot.settings_dict_temp.animal.sell
+        return self.bot.settings_dict_temp.commands.sell
 
     @property
     def sac_settings(self):
-        self.bot.settings_dict_temp.animal.sac
+        return self.bot.settings_dict_temp.commands.sac
 
     def allocate_points(self, command: str, rarities: str):
         if command not in ("sell", "sac"):

--- a/config/misc.json
+++ b/config/misc.json
@@ -37,6 +37,7 @@
         "army": {"priority": 10, "basecd": 60, "log_color": "#a86b32"},
         "piku": {"priority": 10, "basecd": 60, "log_color": "#a86b32"},
         "pup": {"priority": 10, "basecd": 60, "log_color": "#a86b32"},
+        "run": {"priority": 10, "basecd": 60, "log_color": "#a86b32"},
         "customcommand": {"priority": 11, "basecd": 1, "log_color": "#c9a4bc"}
     },
     "alias": {
@@ -73,6 +74,10 @@
         "huntbot": {
             "normal": "ah",
             "alias": ["ah", "hb", "huntbot", "autohunt"]
+        },
+        "run": {
+            "normal": "run",
+            "alias": ["run"]
         },
         "zoo": {
             "normal": "zoo",

--- a/config/settings.json
+++ b/config/settings.json
@@ -173,6 +173,13 @@
                 61,
                 70
             ]
+        },
+        "run": {
+            "enabled": false,
+            "cooldown": [
+                60,
+                70
+            ]
         }
     },
     "gamble": {

--- a/database/database.py
+++ b/database/database.py
@@ -93,6 +93,29 @@ class Database:
             return results[0]["giveaways"]
         return None
 
+    async def fetch_cmd_lastran_time(self, command_name):
+        if command_name not in {"army", "pup", "piku", "run"}:
+            raise ValueError("Invalid command name.")
+        column_name = "run_cmd" if command_name == "run" else command_name
+
+        results = await database_handler.get_from_db(
+            f"SELECT {column_name} FROM user_stats WHERE user_id = ?",
+            (self.bot.user.id,),
+        )
+        if results:
+            return results[0][column_name] or 0
+        return 0
+
+    def update_cmd_lastran_time(self, command_name):
+        if command_name not in {"army", "pup", "piku", "run"}:
+            raise ValueError("Invalid command name.")
+        column_name = "run_cmd" if command_name == "run" else command_name
+
+        database_handler.update_database(
+            f"UPDATE user_stats SET {column_name} = ? WHERE user_id = ?",
+            (self.bot.time_in_seconds(), self.bot.user.id),
+        )
+
     def populate_stats_db(self):
         database_handler.update_database(
             "INSERT OR IGNORE INTO user_stats (user_id, daily, lottery, cookie, giveaways, captchas, cowoncy, boss, boss_ticket) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",

--- a/utils/captcha_solver/yescaptcha.py
+++ b/utils/captcha_solver/yescaptcha.py
@@ -26,7 +26,7 @@ class captchaClient:
         try:
             response = requests.post(url, json={"clientKey": self.api}, timeout=10)
             data = response.json()
-            return int(data.get("balance", 0)) if data.get("errorId") == 0 else 0
+            return float(data.get("balance", 0)) if data.get("errorId") == 0 else 0
         except Exception:
             return 0
 

--- a/utils/configs/settings.py
+++ b/utils/configs/settings.py
@@ -302,6 +302,8 @@ class Commands:
         cmd_list = [
             "hunt",
             "battle",
+            "sell",
+            "sac",
             "pray",
             "curse",
             "lvlGrind",
@@ -309,7 +311,8 @@ class Commands:
             "owo",
             "army",
             "pup",
-            "piku"
+            "piku",
+            "run",
         ]
         for cmd in cmd_list:
             setattr(self, cmd, Command(d.get(cmd, {})))

--- a/uwu.py
+++ b/uwu.py
@@ -603,7 +603,9 @@ class MyClient(commands.Bot):
             "lottery": commands_obj.lottery.enabled,
             "mail": self.settings_dict_temp.mail,
             "others": True,
+            "pupiku": commands_obj.pup.enabled or commands_obj.piku.enabled,
             "reactionbot": reactionbot,
+            "run": commands_obj.run.enabled,
             "sell": commands_obj.sell.enabled or commands_obj.sac.enabled,
             "shop": commands_obj.shop.enabled,
             "slots": gamble_obj.slots.enabled,
@@ -700,13 +702,25 @@ class MyClient(commands.Bot):
             return
         try:
             async with self.lock:
-                for index, command in enumerate(self.checks):
-                    if cmd_data:
-                        if command == cmd_data:
-                            self.checks.pop(index)
-                    else:
-                        if command.get("id", None) == id:
-                            self.checks.pop(index)
+                target_id = id or cmd_data.get("id", None)
+                if cmd_data:
+                    self.checks = [command for command in self.checks if command != cmd_data]
+                else:
+                    self.checks = [
+                        command
+                        for command in self.checks
+                        if command.get("id", None) != id
+                    ]
+                items = []
+                while not self.queue.empty():
+                    item = await self.queue.get()
+                    command = item[2]
+                    if command.get("id", None) != target_id:
+                        items.append(item)
+                for item in items:
+                    await self.queue.put(item)
+                if target_id in self.cmds_state:
+                    self.cmds_state[target_id]["in_queue"] = False
         except Exception as e:
             await self.log(f"Error: {e}, during remove_queue", "#c25560")
 
@@ -1278,7 +1292,7 @@ def create_database(db_path="utils/data/db.sqlite"):
         "CREATE TABLE IF NOT EXISTS gamble_winrate (hour INTEGER PRIMARY KEY, wins INTEGER, losses INTEGER, net INTEGER)"
     )
     c.execute(
-        "CREATE TABLE IF NOT EXISTS user_stats (user_id TEXT PRIMARY KEY, daily REAL, lottery REAL, cookie REAL, giveaways REAL, captchas INTEGER, cowoncy INTEGER, boss REAL, boss_ticket INTEGER, pup INTEGER, piku INTEGER, army INTEGER)"
+        "CREATE TABLE IF NOT EXISTS user_stats (user_id TEXT PRIMARY KEY, daily REAL, lottery REAL, cookie REAL, giveaways REAL, captchas INTEGER, cowoncy INTEGER, boss REAL, boss_ticket INTEGER, pup INTEGER, piku INTEGER, army INTEGER, run_cmd INTEGER)"
     )
     c.execute(
         "CREATE TABLE IF NOT EXISTS meta_data (key TEXT PRIMARY KEY, value INTEGER)"
@@ -1288,6 +1302,12 @@ def create_database(db_path="utils/data/db.sqlite"):
     )
     # Switch to WAL mode.
     c.execute("PRAGMA journal_mode=WAL;")
+
+    for column in ("pup", "piku", "army", "run_cmd"):
+        try:
+            c.execute(f"ALTER TABLE user_stats ADD COLUMN {column} INTEGER")
+        except sqlite3.OperationalError:
+            pass
 
     """# NOTE: Remove this once proper migration for database is in place:
     try:


### PR DESCRIPTION
## Summary

- Add a daily `run` command with configuration, aliases, scheduling, and daily completion tracking.
- Fix `pup` and `piku` scheduling so each command runs independently and stops after its daily limit message.
- Fix command queue removal so completed daily commands are also removed from pending queue entries.
- Fix settings parsing for `sell`/`sac` and decimal YesCaptcha balances.

## Root Cause

Several daily commands were partially wired: `pupiku` was not loaded from the command map, `pup` and `piku` were queued together regardless of individual config, and final daily-limit responses could be ignored by timing validation or pending queue entries. `run` had no dedicated command flow at all.

## Validation

- `python -m json.tool config\settings.json`
- `python -m json.tool config\misc.json`
- `python -m py_compile cogs\pupiku.py cogs\run.py cogs\sell.py uwu.py database\database.py utils\captcha_solver\yescaptcha.py utils\configs\settings.py`
- Local simulations for `pup`, `piku`, and `run` final daily-limit messages.