### PR TITLE
fix: suppress spurious re-queue log when cmd is empty in pupiku.py

### DIFF
--- a/cogs/pupiku.py
+++ b/cogs/pupiku.py
@@ -139,7 +139,7 @@ class Pupiku(BaseCog):
             self.startupFinished = True
             await self.send_pupiku(cmd=cmd, final=final)
             return
-        else:
+        elif cmd:
             print(f"{self.bot.user.name} - failed re-queue {cmd}")
 
         cmd = ""


### PR DESCRIPTION
 cogs/pupiku.py
  - changed else: to elif cmd: so the failed re-queue message
    only prints when there's an actual command, not when cmd is empty