### PR TITLE
refactor: added a single source for channel ids

### DIFF
--- a/core/client.py
+++ b/core/client.py
@@ -203,6 +203,29 @@ class MyClient(commands.Bot):
             self.command_handler_status["state"] = False
             self.state_event.clear()
 
+    @property
+    def active_channel_ids(self):
+        """
+        Single source of truth for the channeliss currently relevant to this
+        client (DM, current main channel, active boss channel, and any
+        enabled pray/curse custom channels). 
+        Recomputed fresh on every access, so it always reflects live state - no caching, no manual syncing required at call sites.
+        """
+        ids = set()
+        if self.cm:
+            ids.add(self.cm.id)
+        if self.dm:
+            ids.add(self.dm.id)
+        if self.boss_channel_id:
+            ids.add(self.boss_channel_id)
+        if self.settings_dict:
+            for cmd_name in ("pray", "curse"):
+                cnf = getattr(self.settings_dict.commands, cmd_name, None)
+                custom = getattr(cnf, "custom_channel", None) if cnf else None
+                if custom and custom.enabled:
+                    ids.add(custom.channel)
+        return ids
+
     async def empty_checks_and_switch(self, channel):
         self.command_handler_status["hold_handler"] = True
         await self.sleep_till(
@@ -569,15 +592,15 @@ class MyClient(commands.Bot):
             "thumbnail",
             "author_image",
         ]
+        format_kwargs = {
+            "username": self.user.name,
+            "userid": self.user.id,
+            "current_time": datetime.now().strftime("%H:%M:%S"),
+            **kwargs,
+        }
         for field in formattable_fields:
             if data.get(field):
-                data[field] = data[field].format(
-                    # I could directly pass **kwargs here? Perhaps after proper documentation!
-                    username=self.user.name,
-                    userid=self.user.id,
-                    current_time=datetime.now().strftime("%H:%M:%S"),
-                    **kwargs,
-                )
+                data[field] = data[field].format(**format_kwargs)
 
         color = data.get("color", None)
         if color:

--- a/core/client.py
+++ b/core/client.py
@@ -205,12 +205,6 @@ class MyClient(commands.Bot):
 
     @property
     def active_channel_ids(self):
-        """
-        Single source of truth for the channeliss currently relevant to this
-        client (DM, current main channel, active boss channel, and any
-        enabled pray/curse custom channels). 
-        Recomputed fresh on every access, so it always reflects live state - no caching, no manual syncing required at call sites.
-        """
         ids = set()
         if self.cm:
             ids.add(self.cm.id)

--- a/core/cogs/captcha.py
+++ b/core/cogs/captcha.py
@@ -331,12 +331,7 @@ class Captcha(BaseCog):
                     )
                 return
 
-        channels = [self.bot.dm.id, self.bot.cm.id, self.bot.boss_channel_id]
-
-        for cmd in ("pray", "curse"):
-            cnf = self.fetch_settings(cmd).custom_channel
-            if cnf.enabled:
-                channels.append(cnf.channel)
+        channels = self.bot.active_channel_ids
 
         if message.channel.id in channels and message.author.id == self.bot.owo_bot_id:
             components = message.components

--- a/core/cogs/reactionbot.py
+++ b/core/cogs/reactionbot.py
@@ -37,14 +37,6 @@ class Reactionbot(BaseCog):
     def reaction_bot_settings(self):
         return self.bot.settings_dict.cooldowns.reactionBot
 
-    def pray_curse_channels(self):
-        channels = []
-        for cmd in ["pray", "curse"]:
-            cnf = self.fetch_settings(cmd)
-            if cnf:
-                channels.append(cnf.custom_channel if cnf.enabled else self.bot.cm.id)
-        return channels
-
     def fetch_settings(self, cmd):
         return getattr(self.bot.settings_dict.commands, cmd)
 
@@ -201,7 +193,7 @@ class Reactionbot(BaseCog):
                         cmd = "hunt" if hunt else "battle"
                         await self.send_cmd(cmd)
 
-            if message.channel.id in self.pray_curse_channels():
+            if message.channel.id in self.bot.active_channel_ids:
                 # check, incomplete!
                 if "**pray/curse**" in message.content and (pray or curse):
                     cmds = []


### PR DESCRIPTION
`refactor`: added a single source for channel ids

**Files changed:**
`client.py`: new active_channel_ids property on MyClient
`captcha.py`: consume it instead of manually rebuilding the channel list
`reactionbot.py`: remove buggy pray_curse_channels() helper, consume active_channel_ids instead (hopefully should fix buugy reactionbot.py ✌)