### PR TITLE
lottery fix

### DIFF
--- a/core/cogs/lottery.py
+++ b/core/cogs/lottery.py
@@ -58,7 +58,7 @@ class Lottery(BaseCog):
 
     @property
     def cmd(self):
-        self._cmd["cmd_argument"] = self.settings.amount
+        self._cmd["cmd_arguments"] = self.settings.amount
         return self._cmd
 
     async def start_lottery(self):


### PR DESCRIPTION
fix: `cmd_argument` typo which caused lottery bet amount to be never applied

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the lottery command configuration so its argument count is returned under the expected field name.
  * Improved compatibility with systems that read lottery command settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->